### PR TITLE
22 Password Toggle Feature Added

### DIFF
--- a/Marigold/View/Auth/SignInView.swift
+++ b/Marigold/View/Auth/SignInView.swift
@@ -24,8 +24,7 @@ struct SignInView: View {
                 TextField("Email", text: $email)
                     .textInputAutocapitalization(.never)
                 
-                SecureField("Password", text: $password)
-                    .textContentType(nil)
+                ToggleableTextField(placeholder:"Password",text:$password).textContentType(nil)
                 
                 Button(
                     action: {

--- a/Marigold/View/Auth/SignUpView.swift
+++ b/Marigold/View/Auth/SignUpView.swift
@@ -8,6 +8,26 @@
 import RealmSwift
 import SwiftUI
 
+struct ToggleableTextField: View {
+    @State private var isSecureField: Bool = true
+    var placeholder:String
+    @Binding var text:String
+    
+    var body: some View{
+        HStack{
+            if isSecureField{
+                SecureField(placeholder,text:$text)
+            }else{
+                TextField(text,text:$text)
+            }
+        }.overlay(alignment: .trailing){
+            Image(systemName: isSecureField ? "eye.slash":"eye").onTapGesture {
+                isSecureField.toggle()
+            }
+        }
+    }
+}
+
 struct SignUpView: View {
     
     @EnvironmentObject private var app: RealmSwift.App
@@ -25,11 +45,9 @@ struct SignUpView: View {
                 TextField("Email", text: $email)
                     .textInputAutocapitalization(.never)
                 
-                SecureField("Password", text: $password)
-                    .textContentType(nil)
-                
-                SecureField("Confirm Password", text: $confirmPassword)
-                    .textContentType(nil)
+                ToggleableTextField(placeholder:"Password",text:$password).textContentType(nil)
+
+                ToggleableTextField(placeholder:"Confirm Password", text: $confirmPassword).textContentType(nil)
                 
                 Button(
                     action: {


### PR DESCRIPTION
### Link to Ticket
- Link to the related ticket: #22 
- 
### Description
<!--- Created a "ToggleableTextField" struct/view for Password and Confirm Password fields to allow toggling between password view and text view.-->

### Images and Screenshots
<!---
<img width="814" alt="image" src="https://github.com/NCSU-App-Development-Club/Marigold-iOS/assets/83493117/4c4daf90-410a-460a-8501-0bddae3bb5f5">
<img width="814" alt="image" src="https://github.com/NCSU-App-Development-Club/Marigold-iOS/assets/83493117/7022be8c-11df-4e90-b96b-13739700fcb8">
<img width="816" alt="image" src="https://github.com/NCSU-App-Development-Club/Marigold-iOS/assets/83493117/416fb68f-dc6c-4a71-b532-d5de055a99e3">
<img width="243" alt="image" src="https://github.com/NCSU-App-Development-Club/Marigold-iOS/assets/83493117/dd009794-54c1-48e0-a5a6-c7d597d105b7">
-->

### Steps to Test
<!---
Please follow the steps below to test the changes in this PR:
1. Step 1
2. Step 2
3. Step 3
... etc.
-->

### Code Checking Checklist
- [x] I have followed the coding standards and guidelines.
- [ ] My code includes proper comments and documentation.
- [x] I have tested my code thoroughly, including edge cases.
- [x] I have ensured that my code doesn't contain any sensitive information (e.g., passwords, keys).
- [x] My changes don't break any existing functionalities.

### Reviewers
<!---
@Majekdor @sr-daniels 
-->

### Additional Notes
<!---
(Optional) Include any other information or notes you have related to this PR.
-->
