### PR TITLE
add a horizontal scroll view container to display upcoming events

### DIFF
--- a/Marigold.xcodeproj/project.pbxproj
+++ b/Marigold.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		453E43BB2A6DFBAD00366A25 /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453E43BA2A6DFBAD00366A25 /* CardView.swift */; };
 		453E43BD2A6E1D5900366A25 /* EventsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453E43BC2A6E1D5900366A25 /* EventsView.swift */; };
 		454681ED2A89955D0033B8D3 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454681EC2A89955D0033B8D3 /* ProfileView.swift */; };
+		DEBF7C942B84710B00A82249 /* EventCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBF7C932B84710B00A82249 /* EventCardView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -47,6 +48,7 @@
 		453E43BA2A6DFBAD00366A25 /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
 		453E43BC2A6E1D5900366A25 /* EventsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsView.swift; sourceTree = "<group>"; };
 		454681EC2A89955D0033B8D3 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		DEBF7C932B84710B00A82249 /* EventCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventCardView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -130,6 +132,7 @@
 				450C5BA32A7DA742005353EC /* WelcomeView.swift */,
 				450C5BAE2A7DD0A1005353EC /* OpenRealmView.swift */,
 				450C5BB02A7DD125005353EC /* SignedInTabView.swift */,
+				DEBF7C932B84710B00A82249 /* EventCardView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -229,6 +232,7 @@
 				450C5BA42A7DA742005353EC /* WelcomeView.swift in Sources */,
 				453E43B62A6DF6AB00366A25 /* Club.swift in Sources */,
 				450C5BA72A7DC9E0005353EC /* SignUpView.swift in Sources */,
+				DEBF7C942B84710B00A82249 /* EventCardView.swift in Sources */,
 				453E43B22A6DF52000366A25 /* User.swift in Sources */,
 				453E43B82A6DF7CF00366A25 /* Event.swift in Sources */,
 				450C5BAD2A7DCFBB005353EC /* SignInView.swift in Sources */,

--- a/Marigold.xcodeproj/project.pbxproj
+++ b/Marigold.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		453E43BD2A6E1D5900366A25 /* EventsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453E43BC2A6E1D5900366A25 /* EventsView.swift */; };
 		454681ED2A89955D0033B8D3 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454681EC2A89955D0033B8D3 /* ProfileView.swift */; };
 		DEBF7C942B84710B00A82249 /* EventCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBF7C932B84710B00A82249 /* EventCardView.swift */; };
+		DEBF7C962B84737100A82249 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBF7C952B84737100A82249 /* HomeView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -49,6 +50,7 @@
 		453E43BC2A6E1D5900366A25 /* EventsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsView.swift; sourceTree = "<group>"; };
 		454681EC2A89955D0033B8D3 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		DEBF7C932B84710B00A82249 /* EventCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventCardView.swift; sourceTree = "<group>"; };
+		DEBF7C952B84737100A82249 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -133,6 +135,7 @@
 				450C5BAE2A7DD0A1005353EC /* OpenRealmView.swift */,
 				450C5BB02A7DD125005353EC /* SignedInTabView.swift */,
 				DEBF7C932B84710B00A82249 /* EventCardView.swift */,
+				DEBF7C952B84737100A82249 /* HomeView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -236,6 +239,7 @@
 				453E43B22A6DF52000366A25 /* User.swift in Sources */,
 				453E43B82A6DF7CF00366A25 /* Event.swift in Sources */,
 				450C5BAD2A7DCFBB005353EC /* SignInView.swift in Sources */,
+				DEBF7C962B84737100A82249 /* HomeView.swift in Sources */,
 				454681ED2A89955D0033B8D3 /* ProfileView.swift in Sources */,
 				453E43B42A6DF64600366A25 /* School.swift in Sources */,
 			);

--- a/Marigold/Model/Club.swift
+++ b/Marigold/Model/Club.swift
@@ -91,7 +91,7 @@ extension Club {
             events: [
                 
             ],
-            imageUrl: ""
+            imageUrl: "https://se-images.campuslabs.com/clink/images/cb91ed74-19da-4075-9df2-a33fa5e3ef595cec3f9a-b48a-45c7-b092-d6ec3882cf62.jpg?preset=med-sq"
         )
     }
 }

--- a/Marigold/View/EventCardView.swift
+++ b/Marigold/View/EventCardView.swift
@@ -1,0 +1,70 @@
+//
+//  EventCardView.swift
+//  Marigold
+//
+//  Created by Devashish Vachhani on 2/20/24.
+//
+
+import SwiftUI
+
+struct EventCardView: View {
+    let event: Event
+    let backgroundColor: Color
+    private var date: String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MM/dd - hh:mm a"
+        return dateFormatter.string(from: event.date)
+    }
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            
+            Text(event.title)
+                .font(.headline)
+                .foregroundColor(.white)
+
+            Spacer()
+            
+            if let club = event.club {
+                HStack(spacing: 20) {
+                    Text(club.shortName)
+                        .font(.subheadline)
+                        .foregroundColor(.white)
+                    
+                    AsyncImage(url: URL(string: club.imageUrl)) { phase in
+                        switch phase {
+                            case .empty:
+                            EmptyView()
+                            case .success(let image):
+                                image
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 25, height: 25)
+                                    .clipShape(Circle())
+                            case .failure:
+                                EmptyView()
+                            @unknown default:
+                                EmptyView()
+                        }
+                    }
+
+                    Spacer()
+                }
+            }
+            
+            Text(date)
+                .font(.caption)
+                .foregroundColor(.white)
+        }
+        .padding()
+        .frame(width: 250, height: 125)
+        .background(backgroundColor)
+        .cornerRadius(12)
+    }
+}
+
+struct EventCardView_Previews: PreviewProvider {
+    static var previews: some View {
+        EventCardView(event: Event.adcMeeting, backgroundColor: .blue)
+    }
+}
+

--- a/Marigold/View/HomeView.swift
+++ b/Marigold/View/HomeView.swift
@@ -1,0 +1,77 @@
+//
+//  HomeView.swift
+//  Marigold
+//
+//  Created by Devashish Vachhani on 2/20/24.
+//
+
+import SwiftUI
+
+struct HomeView: View {
+    // Example data for the static card placeholders
+    let upcomingEvents = [
+        Event(
+            title: "Coding Challenge",
+            body: "",
+            postedBy: .kevinBarnes,
+            club: .adc,
+            date: Date(),
+            postedAt: Date(),
+            attending: [
+                .kevinBarnes
+            ],
+            location: "Engineering Building 2 Room 5",
+            isPrivate: false
+        ),
+        Event(
+            title: "Pickup Soccer",
+            body: "",
+            postedBy: nil,
+            club: Club(
+                fullName: "Club Barcelona Team", shortName: "Club Barcelona Team", school: .ncsu, color: 1, members: [], posts: [], events: [], imageUrl: "https://play-lh.googleusercontent.com/BZwnHy1BTUzctI4htEb2-bS0z2t0aUWtkKaQJle738UDyP0IQ2NB_KvT1ME15JnxTPE"),
+            date: DateComponents(calendar: .current, year: 2024, month: 2, day: 22, hour: 20, minute: 00).date!,
+            postedAt: Date(),
+            attending: [],
+            location: "",
+            isPrivate: false
+        ),
+        Event(
+            title: "Book Fair",
+            body: "",
+            postedBy: nil,
+            club: Club(
+                fullName: "Literature Club", shortName: "Literature Club", school: .ncsu, color: 2, members: [], posts: [], events: [], imageUrl: ""),
+            date: DateComponents(calendar: .current, year: 2024, month: 2, day: 24, hour: 19, minute: 30).date!,
+            postedAt: Date(),
+            attending: [],
+            location: "",
+            isPrivate: false
+        )
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Upcoming Events")
+                .font(.title)
+                .fontWeight(.bold)
+                
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: 20) {
+                    ForEach(upcomingEvents, id: \.self) { event in
+                        let randomColor = Color(red: .random(in: 0...1),
+                                                green: .random(in: 0...1),
+                                                blue: .random(in: 0...1) )
+                        EventCardView(event: event, backgroundColor: randomColor)
+                    }
+                }
+                .padding(.trailing)
+            }
+            .frame(height: 125)
+        }
+        .padding(.leading)
+    }
+}
+
+#Preview {
+    HomeView()
+}


### PR DESCRIPTION
### Link to Ticket
- Link to the related ticket: [#29: Upcoming Events Horizontal Scroll View](https://github.com/NCSU-App-Development-Club/Marigold-iOS/issues/29)
- This PR uses the changes introduced in [PR#36: add layout for a single event card ](https://github.com/NCSU-App-Development-Club/Marigold-iOS/pull/36)
### Description
This pull request introduces a horizontal scroll view container on the homepage to showcase upcoming events. The scroll view is initially populated with static card placeholders, which will be dynamically updated in future iterations to display real event data.

### Images and Screenshots
<img width="635" alt="Screenshot 2024-02-20 at 1 23 42 AM" src="https://github.com/NCSU-App-Development-Club/Marigold-iOS/assets/43621843/02160896-424f-4aa2-88f7-6509ae83bcdd">


### Steps to Test
<!---
Please follow the steps below to test the changes in this PR:
1. Step 1
2. Step 2
3. Step 3
... etc.
-->

### Code Checking Checklist
- [x] I have followed the coding standards and guidelines.
- [x] My code includes proper comments and documentation.
- [x] I have tested my code thoroughly, including edge cases.
- [x] I have ensured that my code doesn't contain any sensitive information (e.g., passwords, keys).
- [x] My changes don't break any existing functionalities.

### Reviewers
<!---
Please add the appropriate reviewers for this PR.
-->

### Additional Notes
In the current implementation, event card background colors are randomly generated, which could affect font legibility. Let's rethink this approach to ensure better readability.
