### PR TITLE
add layout for a single event card

### DIFF
--- a/Marigold.xcodeproj/project.pbxproj
+++ b/Marigold.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		453E43BB2A6DFBAD00366A25 /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453E43BA2A6DFBAD00366A25 /* CardView.swift */; };
 		453E43BD2A6E1D5900366A25 /* EventsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453E43BC2A6E1D5900366A25 /* EventsView.swift */; };
 		454681ED2A89955D0033B8D3 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454681EC2A89955D0033B8D3 /* ProfileView.swift */; };
+		DEBF7C942B84710B00A82249 /* EventCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBF7C932B84710B00A82249 /* EventCardView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -47,6 +48,7 @@
 		453E43BA2A6DFBAD00366A25 /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
 		453E43BC2A6E1D5900366A25 /* EventsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsView.swift; sourceTree = "<group>"; };
 		454681EC2A89955D0033B8D3 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		DEBF7C932B84710B00A82249 /* EventCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventCardView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -130,6 +132,7 @@
 				450C5BA32A7DA742005353EC /* WelcomeView.swift */,
 				450C5BAE2A7DD0A1005353EC /* OpenRealmView.swift */,
 				450C5BB02A7DD125005353EC /* SignedInTabView.swift */,
+				DEBF7C932B84710B00A82249 /* EventCardView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -229,6 +232,7 @@
 				450C5BA42A7DA742005353EC /* WelcomeView.swift in Sources */,
 				453E43B62A6DF6AB00366A25 /* Club.swift in Sources */,
 				450C5BA72A7DC9E0005353EC /* SignUpView.swift in Sources */,
+				DEBF7C942B84710B00A82249 /* EventCardView.swift in Sources */,
 				453E43B22A6DF52000366A25 /* User.swift in Sources */,
 				453E43B82A6DF7CF00366A25 /* Event.swift in Sources */,
 				450C5BAD2A7DCFBB005353EC /* SignInView.swift in Sources */,

--- a/Marigold/Model/Club.swift
+++ b/Marigold/Model/Club.swift
@@ -91,7 +91,7 @@ extension Club {
             events: [
                 
             ],
-            imageUrl: ""
+            imageUrl: "https://se-images.campuslabs.com/clink/images/cb91ed74-19da-4075-9df2-a33fa5e3ef595cec3f9a-b48a-45c7-b092-d6ec3882cf62.jpg?preset=med-sq"
         )
     }
 }

--- a/Marigold/View/EventCardView.swift
+++ b/Marigold/View/EventCardView.swift
@@ -1,0 +1,70 @@
+//
+//  EventCardView.swift
+//  Marigold
+//
+//  Created by Devashish Vachhani on 2/20/24.
+//
+
+import SwiftUI
+
+struct EventCardView: View {
+    let event: Event
+    let backgroundColor: Color
+    private var date: String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MM/dd - hh:mm a"
+        return dateFormatter.string(from: event.date)
+    }
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            
+            Text(event.title)
+                .font(.headline)
+                .foregroundColor(.white)
+
+            Spacer()
+            
+            if let club = event.club {
+                HStack(spacing: 20) {
+                    Text(club.shortName)
+                        .font(.subheadline)
+                        .foregroundColor(.white)
+                    
+                    AsyncImage(url: URL(string: club.imageUrl)) { phase in
+                        switch phase {
+                            case .empty:
+                            EmptyView()
+                            case .success(let image):
+                                image
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 25, height: 25)
+                                    .clipShape(Circle())
+                            case .failure:
+                                EmptyView()
+                            @unknown default:
+                                EmptyView()
+                        }
+                    }
+
+                    Spacer()
+                }
+            }
+            
+            Text(date)
+                .font(.caption)
+                .foregroundColor(.white)
+        }
+        .padding()
+        .frame(width: 250, height: 125)
+        .background(backgroundColor)
+        .cornerRadius(12)
+    }
+}
+
+struct EventCardView_Previews: PreviewProvider {
+    static var previews: some View {
+        EventCardView(event: Event.adcMeeting, backgroundColor: .blue)
+    }
+}
+


### PR DESCRIPTION
### Link to Ticket
- Link to the related ticket: [#28: Event Card Layout](https://github.com/NCSU-App-Development-Club/Marigold-iOS/issues/28)

### Description
This pull request introduces a new EventCard component designed to display information about individual events. The component features key text details from the Event model such as the event's name, club and date while the associated club's image is loaded asynchronously.

### Images and Screenshots
<img width="701" alt="Screenshot 2024-02-19 at 2 18 22 AM" src="https://github.com/NCSU-App-Development-Club/Marigold-iOS/assets/43621843/7d6e2fc5-e7da-4709-8bb4-a72362017ea7">

### Steps to Test
<!---
Please follow the steps below to test the changes in this PR:
1. Step 1
2. Step 2
3. Step 3
... etc.
-->

### Code Checking Checklist
- [x] I have followed the coding standards and guidelines.
- [x] My code includes proper comments and documentation.
- [x] I have tested my code thoroughly, including edge cases.
- [x] I have ensured that my code doesn't contain any sensitive information (e.g., passwords, keys).
- [x] My changes don't break any existing functionalities.

### Reviewers
<!---
Please add the appropriate reviewers for this PR.
-->

### Additional Notes
<!---
(Optional) Include any other information or notes you have related to this PR.
-->
